### PR TITLE
Set size of overlay container to fix layout in Firefox

### DIFF
--- a/stylesheets/_app.sass
+++ b/stylesheets/_app.sass
@@ -241,6 +241,7 @@ main#TimeTableMain
         position: relative
         display: inline-block
         margin-left: 2em
+        width: 33%
         .overlay
           div
             left: 0


### PR DESCRIPTION
Fixes #738. Doesn't change the layout in Chrome.